### PR TITLE
Allow install on ghap machines and better guess_max

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(person("Ryan", "Hafen", email = "rhafen@gmail.com", role = c("aut",
 Description: Utilities for working in GHAP. Not a useful package for the general
     public.
 Depends:
-    R (>= 3.3.1)
+    R (>= 3.2.3)
 Imports:
 Imports: dplyr,plyr,tools,xml2,httr,rvest,utils,readr,osfr,grDevices,DT,reshape2,tibble,d3Tree,R.utils
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,4 +16,4 @@ Suggests:
     sinew,
     testthat
 RoxygenNote: 6.0.1
-Remotes: schloerke/osfr
+Remotes: hafen/osfr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: Utilities for working in GHAP. Not a useful package for the general
 Depends:
     R (>= 3.2.3)
 Imports:
-Imports: dplyr,plyr,tools,xml2,httr,rvest,utils,readr,osfr,grDevices,DT,reshape2,tibble,d3Tree
+Imports: dplyr,plyr,tools,xml2,httr,rvest,utils,readr,osfr,grDevices,DT,reshape2,tibble,d3Tree,R.utils
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(person("Ryan", "Hafen", email = "rhafen@gmail.com", role = c("aut",
 Description: Utilities for working in GHAP. Not a useful package for the general
     public.
 Depends:
-    R (>= 3.3.1)
+    R (>= 3.2.3)
 Imports:
 Imports: dplyr,plyr,tools,xml2,httr,rvest,utils,readr,osfr,grDevices,DT,reshape2,tibble,d3Tree
 License: MIT + file LICENSE
@@ -16,4 +16,4 @@ Suggests:
     sinew,
     testthat
 RoxygenNote: 6.0.1
-Remotes: hafen/osfr
+Remotes: schloerke/osfr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(person("Ryan", "Hafen", email = "rhafen@gmail.com", role = c("aut",
 Description: Utilities for working in GHAP. Not a useful package for the general
     public.
 Depends:
-    R (>= 3.2.3)
+    R (>= 3.3.1)
 Imports:
 Imports: dplyr,plyr,tools,xml2,httr,rvest,utils,readr,osfr,grDevices,DT,reshape2,tibble,d3Tree,R.utils
 License: MIT + file LICENSE

--- a/R/git.R
+++ b/R/git.R
@@ -116,7 +116,7 @@ get_study_list <- function() {
 #' studies <- get_study_list_anthro()
 #' wsb <- use_study("wsb")
 #' }
-use_study <- function(id, defin = FALSE, guess_max = 100000) {
+use_study <- function(id, defin = FALSE, guess_max = -1) {
   path <- get_git_base_path()
 
   studies <- get_study_list()
@@ -187,6 +187,9 @@ use_study <- function(id, defin = FALSE, guess_max = 100000) {
   }
 
   message("Reading ", dat_path)
+  if (identical(guess_max, -1)) {
+    guess_max <- R.utils::countLines(dat_path)
+  }
   d <- suppressMessages(readr::read_csv(dat_path, guess_max = guess_max))
   names(d) <- tolower(names(d))
 

--- a/man/use_study.Rd
+++ b/man/use_study.Rd
@@ -4,7 +4,7 @@
 \alias{use_study}
 \title{Get data for a given study ID}
 \usage{
-use_study(id, defin = FALSE, guess_max = 100000)
+use_study(id, defin = FALSE, guess_max = -1)
 }
 \arguments{
 \item{id}{the study ID - this can either be a short ID or long ID which are found in the ID columns of the result of \code{\link{get_study_list}} or \code{\link{get_study_list_anthro}}}


### PR DESCRIPTION
need to lower the default R value to 3.2.3 to install on ghap machines

changed guess_max to look at the full file by default.  large guesses don't work well enough. i.e. uvg_growth.  pre-allocating larger than necessary is not efficient either.